### PR TITLE
Make dependencies explicit in the gemspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ Or install it yourself as:
 #### Dependencies
 
 * bootstrap-sass
+* coffee-rails
 * font-awesome-rails
+* slim
 
 ## Usage
 

--- a/biola_frontend_toolkit.gemspec
+++ b/biola_frontend_toolkit.gemspec
@@ -18,6 +18,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_dependency "bootstrap-sass",       "~> 3.1"
+  spec.add_dependency "coffee-rails",         "~> 4.0"
+  spec.add_dependency "font-awesome-rails",   "~> 4.2"
+  spec.add_dependency "slim",                 "~> 2.0"
+  spec.add_development_dependency "bundler",  "~> 1.3"
   spec.add_development_dependency "rake"
 end

--- a/lib/biola_frontend_toolkit.rb
+++ b/lib/biola_frontend_toolkit.rb
@@ -1,5 +1,9 @@
 require "biola_frontend_toolkit/version"
 require "biola_frontend_toolkit/engine" if defined?(::Rails)
+require "bootstrap-sass"
+require "coffee-rails"
+require "slim"
+require "font-awesome-rails"
 
 module BiolaFrontendToolkit
   require 'biola_frontend_toolkit/configuration'


### PR DESCRIPTION
Previously the dependencies were just listed in the README.
